### PR TITLE
Ensure numFails does not become negative on success()

### DIFF
--- a/src/CircuitBreaker/Breaker.php
+++ b/src/CircuitBreaker/Breaker.php
@@ -183,6 +183,10 @@ class Breaker
 
         if ($this->threshold > 0) {
             $numFails--;
+
+            if ($numFails < 0) {
+                $numFails = 0;
+            }
         }
 
         $this->log("Current number of fails: ".$numFails);

--- a/tests/CircuitBreaker/BreakerTest.php
+++ b/tests/CircuitBreaker/BreakerTest.php
@@ -44,6 +44,19 @@ class BreakerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($breaker->isClosed(), 'Breaker should be closed before threshold reached');
     }
 
+    public function testBreakerThresholdIsNotAffectedByTheNumberOfPreviousSuccesses() {
+        $threshold = 2;
+        $breaker = new Breaker('testBreaker', new ArrayPersistence, null, array('threshold' => $threshold));
+
+        $breaker->failure();
+        $breaker->success();
+        $breaker->success();
+        $breaker->failure();
+        $breaker->failure();
+
+        $this->assertTrue($breaker->isOpen(), 'Breaker should be open when threshold reached');
+    }
+
     public function testOpenBreakerClosesWhenSuccessRegistered()
     {
         $threshold = 1;


### PR DESCRIPTION
Hi Elisabeth, 

Thanks for making this circuit breaker class, we've found it really helpful :)

This commit fixes an issue where a failure followed by lots of successes causes the numFails value to be large and negative, which means that the breaker does not open after the expected subsequent number of failures.

Thanks,
Lincoln